### PR TITLE
Alpaca truncate

### DIFF
--- a/src/llama_recipes/datasets/alpaca_dataset.py
+++ b/src/llama_recipes/datasets/alpaca_dataset.py
@@ -43,7 +43,6 @@ class InstructionDataset(Dataset):
     def __getitem__(self, index):
         IGNORE_INDEX = -100  # The default setting in CrossEntropyLoss
 
-
         ann = self.ann[index]
         if ann.get("input", "") == "":
             prompt = PROMPT_DICT["prompt_no_input"].format_map(ann)

--- a/src/llama_recipes/datasets/alpaca_dataset.py
+++ b/src/llama_recipes/datasets/alpaca_dataset.py
@@ -68,6 +68,7 @@ class InstructionDataset(Dataset):
             example = torch.cat((example, torch.zeros(padding, dtype=torch.int64) - 1))
         # we truncate the prompt and always keep the response
         elif padding <= 0:
+            print (f'Truncating: {self.max_words} padding: {padding}')
             prompt = prompt[: self.max_words - response.shape[0]]
             example = torch.cat((prompt, response))
 

--- a/src/llama_recipes/datasets/alpaca_dataset.py
+++ b/src/llama_recipes/datasets/alpaca_dataset.py
@@ -5,21 +5,22 @@
 
 import copy
 import json
-
+import os
 import torch
 from torch.utils.data import Dataset
 
+RESPONSE_PROMPT = "\n\n### Response:{output}"
 
 PROMPT_DICT = {
     "prompt_input": (
         "Below is an instruction that describes a task, paired with an input that provides further context. "
         "Write a response that appropriately completes the request.\n\n"
-        "### Instruction:\n{instruction}\n\n### Input:\n{input}\n\n### Response:"
+        "### Instruction:\n{instruction}\n\n### Input:\n{input}"
     ),
     "prompt_no_input": (
         "Below is an instruction that describes a task. "
         "Write a response that appropriately completes the request.\n\n"
-        "### Instruction:\n{instruction}\n\n### Response:"
+        "### Instruction:\n{instruction}"
     ),
 }
 
@@ -48,20 +49,29 @@ class InstructionDataset(Dataset):
             prompt = PROMPT_DICT["prompt_no_input"].format_map(ann)
         else:
             prompt = PROMPT_DICT["prompt_input"].format_map(ann)
-        example = prompt + ann["output"]
+
         prompt = torch.tensor(
             self.tokenizer.encode(prompt), dtype=torch.int64
         )
-        example = self.tokenizer.encode(example)
-        example.append(self.tokenizer.eos_token_id)
-        example = torch.tensor(
-            example, dtype=torch.int64
+
+        response = RESPONSE_PROMPT.format_map(ann)
+        response = self.tokenizer.encode(response)
+        response.append(self.tokenizer.eos_token_id)
+
+        response = torch.tensor(
+            response, dtype=torch.int64
         )
-        padding = self.max_words - example.shape[0]
+
+        padding = self.max_words - (prompt.shape[0] + response.shape[0])
+        print (f'max words: {self.max_words} padding: {padding}' )
         if padding > 0:
+            example = torch.cat((prompt, response))
             example = torch.cat((example, torch.zeros(padding, dtype=torch.int64) - 1))
-        elif padding < 0:
-            example = example[: self.max_words]
+        # we truncate the prompt and always keep the response
+        elif padding <= 0:
+            prompt = prompt[: self.max_words - response.shape[0]]
+            example = torch.cat((prompt, response))
+
         labels = copy.deepcopy(example)
         labels[: len(prompt)] = -1
         example_mask = example.ge(0)

--- a/src/llama_recipes/utils/dataset_utils.py
+++ b/src/llama_recipes/utils/dataset_utils.py
@@ -13,7 +13,7 @@ from llama_recipes.datasets import (
 
 
 DATASET_PREPROC = {
-    "alpaca_dataset": partial(get_alpaca_dataset, max_words=224),
+    "alpaca_dataset": partial(get_alpaca_dataset, max_words=2024),
     "grammar_dataset": get_grammar_dataset,
     "samsum_dataset": get_samsum_dataset,
 }


### PR DESCRIPTION
# What does this PR do?

<!--
The fix was in the alpaca dataset.
The truncation of the training examples (instruction+input+output) to the max_words.
Originally the code built the prompt with all three parts and if it was larger than max_words, the code just removes the last tokens. As a result the response might be removed
I fixed to truncate the (instruction+input) and keep the full response, such that overall it will fit into max_words.
-->

